### PR TITLE
Feat: 기본 DIContainer 생성 및 OTHER_SWIFT_FLAGS 설정 값 추가

### DIFF
--- a/Projects/Core/CoreModels/Sources/Entity/DateEntity.swift
+++ b/Projects/Core/CoreModels/Sources/Entity/DateEntity.swift
@@ -11,4 +11,17 @@ import Foundation
 public struct DateEntity: Decodable, Sendable {
     public let maximum: String
     public let minimum: String
+    
+    public init(
+        maximum: String,
+        minimum: String
+    ) {
+        self.maximum = maximum
+        self.minimum = minimum
+    }
+    
+    public init() {
+        self.maximum = ""
+        self.minimum = ""
+    }
 }

--- a/Projects/Core/CoreModels/Sources/Entity/NowPlaying/NowPlayingEntity.swift
+++ b/Projects/Core/CoreModels/Sources/Entity/NowPlaying/NowPlayingEntity.swift
@@ -35,4 +35,12 @@ public struct NowPlayingEntity: Decodable, Sendable {
         self.totalPages = totalPages
         self.totalResults = totalResults
     }
+    
+    public init() {
+        self.dates = .init()
+        self.page = 0
+        self.results = []
+        self.totalPages = 0
+        self.totalResults = 0
+    }
 }

--- a/Projects/Core/CoreModels/Sources/Entity/NowPlaying/NowPlayingMoviesEntity.swift
+++ b/Projects/Core/CoreModels/Sources/Entity/NowPlaying/NowPlayingMoviesEntity.swift
@@ -18,4 +18,44 @@ public struct NowPlayingMoviesEntity: Decodable, Sendable {
     public let genreIds: [Int]
     public let popularity: Double
     public let adult: Bool
+    
+    public init(
+        id: Int,
+        title: String,
+        overview: String,
+        posterPath: String?,
+        backdropPath: String?,
+        releaseDate: String?,
+        voteAverage: Double,
+        voteCount: Int,
+        genreIds: [Int],
+        popularity: Double,
+        adult: Bool
+    ) {
+        self.id = id
+        self.title = title
+        self.overview = overview
+        self.posterPath = posterPath
+        self.backdropPath = backdropPath
+        self.releaseDate = releaseDate
+        self.voteAverage = voteAverage
+        self.voteCount = voteCount
+        self.genreIds = genreIds
+        self.popularity = popularity
+        self.adult = adult
+    }
+    
+    public init() {
+        self.id = 0
+        self.title = ""
+        self.overview = ""
+        self.posterPath = ""
+        self.backdropPath = ""
+        self.releaseDate = ""
+        self.voteAverage = 0.0
+        self.voteCount = 0
+        self.genreIds = []
+        self.popularity = 0.0
+        self.adult = true
+    }
 }

--- a/Projects/Core/CoreRx/Project.swift
+++ b/Projects/Core/CoreRx/Project.swift
@@ -1,0 +1,19 @@
+//
+//  Project.swift
+//  CoreCommonUIManifests
+//
+//  Created by 박서연 on 12/28/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let CoreRxProject = Project.makeCoreModule(
+    name: "CoreRx",
+    isResource: false,
+    dependencies: [
+        .external(name: "RxSwift"),
+        .external(name: "RxCocoa"),
+        .external(name: "RxRelay")
+    ]
+)

--- a/Projects/Core/CoreRx/Sources/CoreRx.swift
+++ b/Projects/Core/CoreRx/Sources/CoreRx.swift
@@ -1,0 +1,11 @@
+//
+//  CoreRx.swift
+//  CoreRx
+//
+//  Created by 박서연 on 12/28/25.
+//  Copyright © 2025 linda. All rights reserved.
+//
+
+import Foundation
+
+// CoreRx는 RxSwift, RxCocoa, RxRelay의 wrapper 역할을 합니다.

--- a/Projects/Features/HomeFeature/Project.swift
+++ b/Projects/Features/HomeFeature/Project.swift
@@ -16,6 +16,7 @@ let homeFeatureProject = Project.makeFeatureModule(
         .project(target: "CoreUtils", path: "../../Core/CoreUtils"),
         .project(target: "CoreCommonUI", path: "../../Core/CoreCommonUI"),
         .project(target: "DesignSystem", path: "../../DesignSystem"),
-        .external(name: "RxSwift")
+        .project(target: "CoreSecurity", path: "../../Core/CoreSecurity"),
+        .project(target: "CoreRx", path: "../../Core/CoreRx"),
     ]
 )

--- a/Projects/Features/HomeFeature/Sources/Domain/UseCase/DefaultHomeUseCase.swift
+++ b/Projects/Features/HomeFeature/Sources/Domain/UseCase/DefaultHomeUseCase.swift
@@ -9,8 +9,6 @@
 import CoreModels
 import CoreNetwork
 
-import RxSwift
-
 public protocol HomeUseCase {
     func fetchNowPlayingMovies(page: Int) async throws -> NowPlayingEntity
 }

--- a/Projects/Features/HomeFeature/Sources/Presentation/HomeFeatureTest.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/HomeFeatureTest.swift
@@ -9,28 +9,124 @@ import UIKit
 
 import CoreCommonUI
 import CoreNetwork
+import CoreSecurity
 import DesignSystem
 
 public final class HomeViewController: UIViewController {
 
-    private let testButton = DSButton(style: .primary, title: "Design Test")
-
+    private let useCase: HomeUseCase
+    private let saveTokenButton = DSButton(style: .primary, title: "Save API Token to Keychain")
+    private let testButton = DSButton(style: .primary, title: "Fetch Now Playing Movies")
+    private let resultLabel: UILabel = {
+        let label = UILabel()
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 14)
+        label.textColor = .label
+        label.text = "Press 'Save API Token' first, then fetch movies"
+        return label
+    }()
+    
+    public init(useCase: HomeUseCase) {
+        self.useCase = useCase
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
         setupLayout()
+        setupActions()
     }
-
+    
     private func setupUI() {
         view.backgroundColor = DesignSystemColor.background
+        view.addSubview(saveTokenButton)
         view.addSubview(testButton)
+        view.addSubview(resultLabel)
     }
 
     private func setupLayout() {
-        testButton.snp.makeConstraints { make in
-            make.center.equalToSuperview()
-            make.width.equalTo(180)
+        saveTokenButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.centerY.equalToSuperview().offset(-150)
+            make.width.equalTo(250)
             make.height.equalTo(52)
+        }
+
+        testButton.snp.makeConstraints { make in
+            make.centerX.equalToSuperview()
+            make.top.equalTo(saveTokenButton.snp.bottom).offset(20)
+            make.width.equalTo(250)
+            make.height.equalTo(52)
+        }
+
+        resultLabel.snp.makeConstraints { make in
+            make.top.equalTo(testButton.snp.bottom).offset(40)
+            make.leading.equalToSuperview().offset(20)
+            make.trailing.equalToSuperview().offset(-20)
+        }
+    }
+
+    private func setupActions() {
+        saveTokenButton.addTarget(self, action: #selector(saveTokenTapped), for: .touchUpInside)
+        testButton.addTarget(self, action: #selector(fetchMoviesTapped), for: .touchUpInside)
+    }
+
+    @objc private func saveTokenTapped() {
+        guard let token = Bundle.main.object(forInfoDictionaryKey: "TMDB_ACCESS_TOKEN") as? String else {
+            resultLabel.text = "❌ Error: TMDB_ACCESS_TOKEN not found in Info.plist"
+            return
+        }
+
+        let keyStore = KeychainAPIKeyStore()
+
+        do {
+            try keyStore.save(token)
+            resultLabel.text = "✅ API Token saved to Keychain successfully!"
+        } catch {
+            resultLabel.text = "❌ Failed to save token:\n\(error.localizedDescription)"
+        }
+    }
+
+    @objc private func fetchMoviesTapped() {
+        resultLabel.text = "Loading..."
+
+        let useCase = self.useCase
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let entity = try await useCase.fetchNowPlayingMovies(page: 1)
+
+                await MainActor.run {
+                    let movieCount = entity.results.count
+                    let firstMovie = entity.results.first
+
+                    var resultText = "✅ Success!\n\n"
+                    resultText += "Total Results: \(entity.totalResults)\n"
+                    resultText += "Total Pages: \(entity.totalPages)\n"
+                    resultText += "Current Page: \(entity.page)\n"
+                    resultText += "Movies Loaded: \(movieCount)\n\n"
+
+                    if let movie = firstMovie {
+                        resultText += "First Movie:\n"
+                        resultText += "Title: \(movie.title)\n"
+                        resultText += "Release: \(movie.releaseDate)"
+                    }
+
+                    self.resultLabel.text = resultText
+                }
+            } catch {
+                await MainActor.run {
+                    self.resultLabel.text = "❌ Error:\n\(error.localizedDescription)"
+                }
+            }
         }
     }
 }

--- a/Projects/Features/HomeFeature/Sources/Presentation/HomeViewModel.swift
+++ b/Projects/Features/HomeFeature/Sources/Presentation/HomeViewModel.swift
@@ -1,0 +1,128 @@
+//
+//  HomeViewModel.swift
+//  HomeFeature
+//
+//  Created by 박서연 on 12/28/25.
+//  Copyright © 2025 linda. All rights reserved.
+//
+
+import Foundation
+import CoreModels
+import CoreSecurity
+
+import RxSwift
+import RxRelay
+import RxCocoa
+
+public final class HomeViewModel {
+
+    // MARK: - Input
+    struct Input {
+        let saveTokenTapped: Observable<Void>
+        let fetchMoviesTapped: Observable<Void>
+    }
+
+    // MARK: - Output
+    struct Output {
+        let resultText: Driver<String>
+        let isLoading: Driver<Bool>
+    }
+
+    // MARK: - Properties
+    private let useCase: HomeUseCase
+    private let keyStore: APIKeyStore
+    private let disposeBag = DisposeBag()
+
+    // MARK: - Init
+    public init(
+        useCase: HomeUseCase,
+        keyStore: APIKeyStore = KeychainAPIKeyStore()
+    ) {
+        self.useCase = useCase
+        self.keyStore = keyStore
+    }
+
+    // MARK: - Transform
+    func transform(input: Input) -> Output {
+        let isLoadingRelay = BehaviorRelay<Bool>(value: false)
+        let resultTextRelay = BehaviorRelay<String>(
+            value: "Press 'Save API Token' first, then fetch movies"
+        )
+
+        // Save Token
+        input.saveTokenTapped
+            .subscribe(onNext: { [weak self] in
+                self?.saveToken(to: resultTextRelay)
+            })
+            .disposed(by: disposeBag)
+
+        // Fetch Movies
+        input.fetchMoviesTapped
+            .do(onNext: {
+                resultTextRelay.accept("Loading...")
+                isLoadingRelay.accept(true)
+            })
+            .flatMapLatest { [weak self] () -> Single<NowPlayingEntity> in
+                guard let self else { return .never() }
+                
+                nonisolated(unsafe) let useCase = self.useCase
+                
+                // ✅ RxSwift의 Swift Concurrency 지원 생성자 사용!
+                return Single.create {
+                    try await useCase.fetchNowPlayingMovies(page: 1)
+                }
+            }
+            .asObservable()
+            .observe(on: MainScheduler.instance)
+            .do(
+                onNext: { _ in isLoadingRelay.accept(false) },
+                onError: { _ in isLoadingRelay.accept(false) }
+            )
+            .subscribe(
+                onNext: { entity in
+                    let movieCount = entity.results.count
+                    let firstMovie = entity.results.first
+
+                    var resultText = "✅ Success!\n\n"
+                    resultText += "Total Results: \(entity.totalResults)\n"
+                    resultText += "Total Pages: \(entity.totalPages)\n"
+                    resultText += "Current Page: \(entity.page)\n"
+                    resultText += "Movies Loaded: \(movieCount)\n\n"
+
+                    if let movie = firstMovie {
+                        resultText += "First Movie:\n"
+                        resultText += "Title: \(movie.title)\n"
+                        resultText += "Release: \(movie.releaseDate)"
+                    }
+
+                    resultTextRelay.accept(resultText)
+                },
+                onError: { error in
+                    resultTextRelay.accept("❌ Error:\n\(error.localizedDescription)")
+                }
+            )
+            .disposed(by: disposeBag)
+
+        return Output(
+            resultText: resultTextRelay.asDriver(),
+            isLoading: isLoadingRelay.asDriver()
+        )
+    }
+
+    // MARK: - Private Methods
+    private func saveToken(to relay: BehaviorRelay<String>) {
+        guard let token = Bundle.main.object(
+            forInfoDictionaryKey: "TMDB_ACCESS_TOKEN"
+        ) as? String else {
+            relay.accept("❌ Error: TMDB_ACCESS_TOKEN not found in Info.plist")
+            return
+        }
+
+        do {
+            try keyStore.save(token)
+            relay.accept("✅ API Token saved to Keychain successfully!")
+        } catch {
+            relay.accept("❌ Failed to save token:\n\(error.localizedDescription)")
+        }
+    }
+}

--- a/Projects/Features/SearchFeature/Project.swift
+++ b/Projects/Features/SearchFeature/Project.swift
@@ -14,8 +14,11 @@ let searchFeatureProject = Project.makeFeatureModule(
         .project(target: "CoreNetwork", path: "../../Core/CoreNetwork"),
         .project(target: "CoreModels", path: "../../Core/CoreModels"),
         .project(target: "CoreUtils", path: "../../Core/CoreUtils"),
+        .project(target: "CoreRx", path: "../../Core/CoreRx"),
         .project(target: "CoreCommonUI", path: "../../Core/CoreCommonUI"),
         .project(target: "DesignSystem", path: "../../DesignSystem"),
-        .external(name: "RxSwift")
+//        .external(name: "RxSwift"),
+//        .external(name: "RxCocoa"),
+//        .external(name: "RxRelay")
     ]
 )

--- a/Projects/YeonFlixApp/Project.swift
+++ b/Projects/YeonFlixApp/Project.swift
@@ -12,6 +12,6 @@ let project = Project.makeAppModule(
     name: "YeonFlixApp",
     dependencies: [
         .project(target: "HomeFeature", path: "../Features/HomeFeature"),
-        .project(target: "SearchFeature", path: "../Features/SearchFeature"),
+        .project(target: "SearchFeature", path: "../Features/SearchFeature")
     ]
 )

--- a/Projects/YeonFlixApp/Sources/Application/AppDelegate.swift
+++ b/Projects/YeonFlixApp/Sources/Application/AppDelegate.swift
@@ -21,7 +21,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         window = UIWindow(frame: UIScreen.main.bounds)
 
-        let homeVC = HomeViewController()
+        let diContainer = AppDIContainer()
+        let homeVC = HomeViewController(useCase: diContainer.makeHomeFeatureDIContainer().makeHomeUseCase())
         let nav = UINavigationController(rootViewController: homeVC)
 
         window?.rootViewController = nav

--- a/Projects/YeonFlixApp/Sources/Application/AppDelegate.swift
+++ b/Projects/YeonFlixApp/Sources/Application/AppDelegate.swift
@@ -22,8 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window = UIWindow(frame: UIScreen.main.bounds)
 
         let diContainer = AppDIContainer()
-        let homeVC = HomeViewController(useCase: diContainer.makeHomeFeatureDIContainer().makeHomeUseCase())
-        let nav = UINavigationController(rootViewController: homeVC)
+        let homeVC = HomeViewModel(useCase: diContainer.makeHomeFeatureDIContainer().makeHomeUseCase())
+        let homeView = HomeViewController(viewModel: homeVC)
+        let nav = UINavigationController(rootViewController: homeView)
 
         window?.rootViewController = nav
         window?.makeKeyAndVisible()

--- a/Projects/YeonFlixApp/Sources/DIContainer/AppDIContainer.swift
+++ b/Projects/YeonFlixApp/Sources/DIContainer/AppDIContainer.swift
@@ -1,0 +1,70 @@
+//
+//  AppDIContainer.swift
+//  YeonFlixApp
+//
+//  Created by 박서연 on 12/25/25.
+//  Copyright © 2025 linda. All rights reserved.
+//
+
+import Foundation
+
+import CoreNetwork
+import CoreSecurity
+
+final class AppDIContainer {
+    
+    // MARK: - Configuration
+    private lazy var apiConfig: APIConfig = {
+        guard let baseURL = URL(string: "https://api.themoviedb.org/3")
+        else {
+            fatalError("Invalid TMDB base URL")
+        }
+        
+        return APIConfig(
+            baseURL: baseURL,
+            defaultHeaders: [:],
+            defaultQueryItems: []
+        )
+    }()
+    
+    // MARK: - Security
+    private lazy var apiKeyStore: APIKeyStore = {
+        KeychainAPIKeyStore()
+    }()
+    
+    private lazy var authHeaderProvider: AuthHeaderProvider = {
+        DefaultAuthHeaderProvider(keyStore: apiKeyStore)
+    }()
+    
+    // Network
+    private lazy var urlRequestBuilder: URLRequestBuilder = {
+        DefaultURLRequestBuilder(authHeaderProvider: authHeaderProvider)
+    }()
+    
+    private lazy var urlSessionProvider: URLSessionProvider = {
+        DefaultURLSessionProvider()
+    }()
+    
+    private lazy var networkService: NetworkService = {
+        DefaultNetworkService(
+            config: apiConfig,
+            requestBuilder: urlRequestBuilder,
+            sessionProvider: urlSessionProvider
+        )
+    }()
+    
+    // MARK: - DataSource
+    private lazy var movieNetworkDataSource: MovieNetworkDataSource = {
+        DefaultMovieDataSource(
+            networkService: networkService,
+            apiConfig: apiConfig
+        )
+    }()
+    
+    // MARK: - Feature Containers
+    func makeHomeFeatureDIContainer() -> HomeFeatureDIContainer {
+        HomeFeatureDIContainer(
+            movieNetworkDataSource: movieNetworkDataSource
+        )
+    }
+}

--- a/Projects/YeonFlixApp/Sources/DIContainer/HomeFeatureDIContainer.swift
+++ b/Projects/YeonFlixApp/Sources/DIContainer/HomeFeatureDIContainer.swift
@@ -1,0 +1,30 @@
+//
+//  HomeFeatureDIContainer.swift
+//  YeonFlixApp
+//
+//  Created by 박서연 on 12/27/25.
+//  Copyright © 2025 linda. All rights reserved.
+//
+
+import CoreNetwork
+import HomeFeature
+
+public final class HomeFeatureDIContainer {
+    
+    private let movieNetworkDataSource: MovieNetworkDataSource
+    
+    public init(movieNetworkDataSource: MovieNetworkDataSource) {
+        self.movieNetworkDataSource = movieNetworkDataSource
+    }
+    
+    // MARK: - Repository
+    private func makeHomeRepository() -> HomeRepository {
+        return DefaultHomeRepository(remoteNetwork:
+                                        movieNetworkDataSource)
+    }
+    
+    // MARK: - UseCase
+    public func makeHomeUseCase() -> HomeUseCase {
+        return DefaultHomeUseCase(repository: makeHomeRepository())
+    }
+}

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fca159cde0495caa022b436b18313f4ebcaf3d8248244a48047732e7d5148a63",
+  "originHash" : "a2bfaffa732aca0168b09365fc06232dc3cb80fb8ef000a59f85ab9b261bcab9",
   "pins" : [
     {
       "identity" : "kingfisher",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveX/RxSwift.git",
       "state" : {
-        "revision" : "5004a18539bd68905c5939aa893075f578f4f03d",
-        "version" : "6.9.1"
+        "revision" : "c7c7d2cf50a3211fe2843f76869c698e4e417930",
+        "version" : "6.8.0"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -17,6 +17,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.10.0"),
         .package(url: "https://github.com/SnapKit/SnapKit", from: "5.7.1"),
-        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.6.0")
+        .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "6.8.0")
       ]
 )

--- a/Tuist/ProjectDescriptionHelpers/Template/Settings+Templates.swift
+++ b/Tuist/ProjectDescriptionHelpers/Template/Settings+Templates.swift
@@ -14,20 +14,29 @@ public extension Settings {
                 "SWIFT_VERSION": "6.0",
                 // Swift 버전 고정
                 "IPHONEOS_DEPLOYMENT_TARGET": "16.0", // 최소 지원 타겟 고정,
-                "OTHER_LDFLAGS": "-ObjC", // 카테고리나 메타데이터가 포함된 정적 라이브러리의 코드가 런타임에 정상 동작하도록 설정
+                "OTHER_SWIFT_FLAGS": [
+                    "$(inherited)",
+                    "-DMYCUSTOMFLAG"
+                ]
             ],
             configurations: [
                 .debug(
                     name: .debug,
                     settings: [
-                        "OTHER_SWIFT_FLAGS": "-DDEBUG", //  #if DEBUG 조건을 가능하도록 설정
+                        "OTHER_SWIFT_FLAGS": [
+                            "$(inherited)",
+                            "-DDEBUG"
+                        ]
                     ],
                     xcconfig: .relativeToRoot("Tuist/Config/Secrets.xcconfig")
                 ),
                 .release(
                     name: .release,
                     settings: [
-                        "OTHER_SWIFT_FLAGS": ["-DRELEASE"], // Swift 코드에서 #if RELEASE 조건을 가능하게 함
+                        "OTHER_SWIFT_FLAGS": [
+                            "$(inherited)",
+                            "-DRELEASE"
+                        ]
                     ],
                     xcconfig: .relativeToRoot("Tuist/Config/Secrets.xcconfig")
                 )


### PR DESCRIPTION
# 제목 
#5  Feat: 기본 DIContainer 생성

## 작업 내용
- AppDIContainer -> Feature 별 DIContainer를 위한 기본 구조 생성 완료
- 테스트 코드로 HomeViewController/HomeViewModel을 추가하고 작업하는 도중 RxCocoa가 인식되지 않는 문제가 발생함 `Missing required module 'RxCocoaRuntime'`
- [#7120](https://github.com/tuist/tuist/issues/7120) 를 참고하여 해결

## 이슈 관련 정리 내용
### 이슈 요약 (Tuist + RxSwift에서 RxCocoa가 안 잡히는 문제)
- Tuist에서 RxSwift 패키지(예: RxCocoa)를 SPM으로 붙여 사용 중, 특정 설정 조합에서 컴파일 시 아래 에러가 발생함 (Missing required module 'RxCocoaRuntime')  
  
**[#7120](https://github.com/tuist/tuist/issues/7120)에서 보고된 재현 조건은**
- Project 레벨과 Target 레벨에 동일한 custom settings 를 걸어두고, 그 settings 안에서 OTHER_SWIFT_FLAGS를 커스텀으로 설정할 때, RxCocoa import 시 RxCocoaRuntime를 찾지 못하는 컴파일 에러가 발생함  ￼
- 이슈 본문에서는 “타겟에서 custom settings를 제거하면 빌드가 된다”는 형태로 증상이 정리되어 있음 
  
### 원인 및 해결 방법
```swift
"OTHER_SWIFT_FLAGS": [
  "$(inherited)",
]
```
- 원인은 프로젝트에서 OTHER_SWIFT_FLAGS를 커스텀 설정하면서 $(inherited)를 포함하지 않아 Tuist/Xcode가 자동 주입하는 필수 플래그가 덮어써졌기 때문으로 추정됨 
- 해결은 OTHER_SWIFT_FLAGS를 배열 형태로 지정하고 $(inherited)를 첫 값으로 포함해 기존 자동 플래그를 유지한 뒤, 커스텀 플래그(-DDEBUG/-DRELEASE)를 병합하는 방식으로 적용했으며, 적용 후 동일 에러가 해소함
